### PR TITLE
feat: add integration scaffolding

### DIFF
--- a/app/config/env.sample.js
+++ b/app/config/env.sample.js
@@ -1,0 +1,21 @@
+export const ENV = {
+  FIREBASE: {
+    apiKey: "TODO",
+    authDomain: "TODO",
+    projectId: "TODO",
+    storageBucket: "TODO",
+    appId: "TODO",
+    messagingSenderId: "TODO"
+  },
+  CF_BASE_URL: "https://<region>-<project>.cloudfunctions.net", // TODO
+  TRACCAR: {
+    baseUrl: "https://traccar.example/api", // НЕ хранить секреты в клиенте
+    user: "TODO", // использовать только через сервер
+    token: "TODO" // использовать только через сервер
+  },
+  KASPI: {
+    merchantId: "TODO",    // НЕ класть секреты в клиент
+    checkoutBase: "https://kaspi.kz/payments" // пример; реальные вызовы через Cloud Functions
+  }
+};
+// Пользователь создаёт app/config/env.js с реальными значениями (не коммитить).

--- a/app/firebase-messaging-sw.js
+++ b/app/firebase-messaging-sw.js
@@ -1,0 +1,36 @@
+self.addEventListener('push', e => {
+  let data = {};
+  if (e.data) {
+    try {
+      data = e.data.json();
+    } catch (err) {
+      data = { title: e.data.text() };
+    }
+  }
+  const title = data.title || 'EcoBike';
+  const options = {
+    body: data.body || '',
+    icon: data.icon || '/app/icons/icon-192.svg',
+    data: { url: data.url || '/' }
+  };
+  e.waitUntil(self.registration.showNotification(title, options));
+});
+
+self.addEventListener('notificationclick', e => {
+  e.notification.close();
+  const url = e.notification.data && e.notification.data.url;
+  e.waitUntil(
+    self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then(clients => {
+      for (const client of clients) {
+        if ('focus' in client) {
+          client.focus();
+          if (url) client.navigate(url);
+          return;
+        }
+      }
+      if (self.clients.openWindow) {
+        return self.clients.openWindow(url || '/');
+      }
+    })
+  );
+});

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -258,5 +258,16 @@
     "limitExceeded": "Daily limit exceeded",
     "noCharged": "No charged batteries",
     "stationDown": "Station unavailable"
+  },
+  "integrations": {
+    "pushPermissionTitle": "Enable notifications",
+    "pushPermissionBody": "We use them for important updates",
+    "enablePush": "Enable push",
+    "enabled": "Push enabled",
+    "denied": "Push denied",
+    "paymentInit": "Opening payment...",
+    "paymentWaiting": "Waiting for payment...",
+    "paymentPaid": "Payment successful",
+    "paymentFailed": "Payment failed"
   }
 }

--- a/app/i18n/kz.json
+++ b/app/i18n/kz.json
@@ -259,5 +259,16 @@
     "limitExceeded": "Күндік лимит асқан",
     "noCharged": "Зарядталған батарея жоқ",
     "stationDown": "Станция жұмыс істемейді"
+  },
+  "integrations": {
+    "pushPermissionTitle": "Хабарламаларды қосу",
+    "pushPermissionBody": "Маңызды жаңартулар үшін қолданамыз",
+    "enablePush": "Push қосу",
+    "enabled": "Push қосылды",
+    "denied": "Push рұқсат етілмеді",
+    "paymentInit": "Төлем ашылуда...",
+    "paymentWaiting": "Төлем күтілуде...",
+    "paymentPaid": "Төлем сәтті",
+    "paymentFailed": "Төлем орындалмады"
   }
 }

--- a/app/i18n/ru.json
+++ b/app/i18n/ru.json
@@ -258,5 +258,16 @@
     "limitExceeded": "Превышен дневной лимит",
     "noCharged": "Нет заряженных батарей",
     "stationDown": "Станция недоступна"
+  },
+  "integrations": {
+    "pushPermissionTitle": "Включить уведомления",
+    "pushPermissionBody": "Мы используем их для важных сообщений",
+    "enablePush": "Включить push",
+    "enabled": "Push включён",
+    "denied": "Push запрещён",
+    "paymentInit": "Открываем оплату...",
+    "paymentWaiting": "Ожидание оплаты...",
+    "paymentPaid": "Оплата прошла",
+    "paymentFailed": "Оплата не прошла"
   }
 }

--- a/app/service-worker.js
+++ b/app/service-worker.js
@@ -19,6 +19,7 @@ const APP_SHELL = [
   '/assets/illustrations/docs.svg',
   '/data/cities.json'
 ];
+try { importScripts('./firebase-messaging-sw.js'); } catch (e) {}
 
 self.addEventListener('install', evt => {
   evt.waitUntil(caches.open(CACHE_NAME).then(c => c.addAll(APP_SHELL)));

--- a/app/utils/firebase.js
+++ b/app/utils/firebase.js
@@ -1,0 +1,97 @@
+let firebaseApp = null;
+
+async function loadEnv() {
+  if (loadEnv.cache) return loadEnv.cache;
+  try {
+    loadEnv.cache = await import('../config/env.js');
+  } catch (e) {
+    loadEnv.cache = await import('../config/env.sample.js');
+  }
+  return loadEnv.cache;
+}
+
+function loadScript(src) {
+  return new Promise((resolve, reject) => {
+    const s = document.createElement('script');
+    s.src = src;
+    s.onload = resolve;
+    s.onerror = reject;
+    document.head.appendChild(s);
+  });
+}
+
+export async function initFirebase(env) {
+  if (firebaseApp) return firebaseApp;
+  if (!env) {
+    const { ENV } = await loadEnv();
+    env = ENV.FIREBASE;
+  }
+  if (!env || env.apiKey === 'TODO') {
+    console.warn('Firebase config missing, skipped init');
+    return null;
+  }
+  const base = 'https://www.gstatic.com/firebasejs/10.11.0/';
+  await loadScript(base + 'firebase-app-compat.js');
+  await Promise.all([
+    loadScript(base + 'firebase-auth-compat.js'),
+    loadScript(base + 'firebase-firestore-compat.js'),
+    loadScript(base + 'firebase-storage-compat.js'),
+    env.messagingSenderId ? loadScript(base + 'firebase-messaging-compat.js') : Promise.resolve()
+  ]);
+  firebaseApp = firebase.initializeApp(env);
+  return firebaseApp;
+}
+
+export function getApp() {
+  return firebaseApp;
+}
+
+export function getAuth() {
+  return firebase.auth();
+}
+
+export function getDb() {
+  return firebase.firestore();
+}
+
+export function getStorage() {
+  return firebase.storage();
+}
+
+export function getMessagingOrNull() {
+  try {
+    return firebase.messaging && firebase.messaging.isSupported && firebase.messaging.isSupported() ? firebase.messaging() : null;
+  } catch (e) {
+    return null;
+  }
+}
+
+export async function signInWithPhoneMock(phone) {
+  await initFirebase();
+  return new Promise(res => setTimeout(() => res({ user: { uid: 'mock-' + phone, phoneNumber: phone } }), 300));
+}
+
+export async function dbGet(path) {
+  await initFirebase();
+  const doc = await getDb().doc(path).get();
+  return doc.exists ? doc.data() : null;
+}
+
+export async function dbSet(path, data) {
+  await initFirebase();
+  return getDb().doc(path).set(data);
+}
+
+export async function dbUpdate(path, data) {
+  await initFirebase();
+  return getDb().doc(path).update(data);
+}
+
+export async function uploadFile(path, file) {
+  await initFirebase();
+  const ref = getStorage().ref(path);
+  if (typeof file === 'string') {
+    return ref.putString(file, 'data_url');
+  }
+  return ref.put(file);
+}

--- a/app/utils/functions.js
+++ b/app/utils/functions.js
@@ -1,0 +1,67 @@
+async function loadEnv() {
+  if (loadEnv.cache) return loadEnv.cache;
+  try {
+    loadEnv.cache = await import('../config/env.js');
+  } catch (e) {
+    loadEnv.cache = await import('../config/env.sample.js');
+  }
+  return loadEnv.cache;
+}
+
+function delay(ms) {
+  return new Promise(r => setTimeout(r, ms));
+}
+
+export async function callCF(baseURL, name, payload = {}, method = 'POST') {
+  if (!baseURL || baseURL === 'TODO') {
+    await delay(300 + Math.random() * 300);
+    return { ok: true, data: { mock: true } };
+  }
+  try {
+    const res = await fetch(`${baseURL}/${name}`, {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+    const data = await res.json().catch(() => null);
+    if (!res.ok) return { ok: false, error: data || res.statusText };
+    return { ok: true, data };
+  } catch (e) {
+    return { ok: false, error: e.message };
+  }
+}
+
+export async function swapBattery({ stationId, slot, userId }) {
+  const { ENV } = await loadEnv();
+  const base = ENV.CF_BASE_URL;
+  if (!base || base === 'TODO') {
+    await delay(300 + Math.random() * 300);
+    return { ok: true, data: { opId: `mock_${Date.now()}` } };
+  }
+  return callCF(base, 'swapBattery', { stationId, slot, userId });
+}
+
+export async function reportSwapSuccess({ opId, stationId, slot, userId }) {
+  const { ENV } = await loadEnv();
+  const base = ENV.CF_BASE_URL;
+  if (!base || base === 'TODO') {
+    await delay(300 + Math.random() * 300);
+    return { ok: true, data: { success: true } };
+  }
+  return callCF(base, 'reportSwapSuccess', { opId, stationId, slot, userId });
+}
+
+export async function getStationCommand({ stationId }) {
+  const { ENV } = await loadEnv();
+  const base = ENV.CF_BASE_URL;
+  if (!base || base === 'TODO') {
+    await delay(300 + Math.random() * 300);
+    return { ok: true, data: { command: null } };
+  }
+  return callCF(base, 'getStationCommand', { stationId });
+}
+
+export async function subscribeTopicMock(cityId) {
+  await delay(300 + Math.random() * 300);
+  return { ok: true, cityId };
+}

--- a/app/utils/payments.js
+++ b/app/utils/payments.js
@@ -1,0 +1,38 @@
+async function loadEnv() {
+  if (loadEnv.cache) return loadEnv.cache;
+  try {
+    loadEnv.cache = await import('../config/env.js');
+  } catch (e) {
+    loadEnv.cache = await import('../config/env.sample.js');
+  }
+  return loadEnv.cache;
+}
+
+function delay(ms) {
+  return new Promise(r => setTimeout(r, ms));
+}
+
+export async function createSessionMock({ planId, amountKZT }) {
+  const { ENV } = await loadEnv();
+  await delay(200);
+  return {
+    ok: true,
+    sessionId: `sess_${Date.now()}`,
+    checkoutUrl: `${ENV.KASPI.checkoutBase}/mock/${planId}`
+  };
+}
+
+export async function pollStatusMock(sessionId) {
+  await delay(200);
+  const states = pollStatusMock._states || (pollStatusMock._states = {});
+  if (!states[sessionId]) {
+    states[sessionId] = 'pending';
+  } else if (states[sessionId] === 'pending') {
+    states[sessionId] = Math.random() > 0.5 ? 'paid' : 'failed';
+  }
+  return { ok: true, status: states[sessionId] };
+}
+
+export function openCheckout(url) {
+  window.open(url, '_blank');
+}

--- a/app/utils/push.js
+++ b/app/utils/push.js
@@ -1,0 +1,45 @@
+import { initFirebase, getMessagingOrNull } from './firebase.js';
+import { subscribeTopicMock } from './functions.js';
+
+async function loadEnv() {
+  if (loadEnv.cache) return loadEnv.cache;
+  try {
+    loadEnv.cache = await import('../config/env.js');
+  } catch (e) {
+    loadEnv.cache = await import('../config/env.sample.js');
+  }
+  return loadEnv.cache;
+}
+
+export async function requestPushPermission() {
+  try {
+    return await Notification.requestPermission();
+  } catch (e) {
+    console.error('Notification permission error', e);
+    return 'denied';
+  }
+}
+
+export async function registerMessagingSW() {
+  if ('serviceWorker' in navigator) {
+    return navigator.serviceWorker.register('/app/firebase-messaging-sw.js');
+  }
+  return null;
+}
+
+export async function getFcmTokenIfPossible() {
+  await initFirebase();
+  const messaging = getMessagingOrNull();
+  if (!messaging) return null;
+  const { ENV } = await loadEnv();
+  try {
+    return await messaging.getToken({ vapidKey: ENV.FIREBASE?.vapidKey || 'TODO' });
+  } catch (e) {
+    console.error('FCM token error', e);
+    return null;
+  }
+}
+
+export function subscribeCityTopic(cityId) {
+  return subscribeTopicMock(cityId);
+}

--- a/app/utils/traccar.js
+++ b/app/utils/traccar.js
@@ -1,0 +1,18 @@
+export async function fetchLastPositionMock(bikeId) {
+  return {
+    ok: true,
+    pos: {
+      lat: 43.24,
+      lng: 76.91,
+      speedKmh: 12,
+      tsISO: new Date().toISOString()
+    }
+  };
+}
+
+export async function fetchMonthlyKmMock(userId) {
+  return {
+    ok: true,
+    km: 132
+  };
+}


### PR DESCRIPTION
## Summary
- add env sample and Firebase lazy init with CDN scripts
- scaffold push notifications, Cloud Functions helpers, and payment/tracking mocks
- integrate basic FCM service worker and translations

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a9a90bece8832cb9fa1664e873d708