### PR TITLE
feat(admin): add trips, tariffs and exchanges resources

### DIFF
--- a/ecobike-admin/src/App.js
+++ b/ecobike-admin/src/App.js
@@ -16,6 +16,9 @@ import dataProvider from './dataProvider';
 import { UserList, UserEdit, UserShow, UserCreate } from './resources/users';
 import { StationList, StationEdit, StationShow, StationCreate } from './resources/stations';
 import { BatteryList, BatteryEdit, BatteryShow } from './resources/batteries';
+import { ExchangeList, ExchangeShow } from './resources/exchanges';
+import { TariffList, TariffEdit, TariffShow, TariffCreate } from './resources/tariffs';
+import { TripList, TripShow } from './resources/trips';
 
 // Дополнительные страницы
 import Analytics from './components/Analytics';
@@ -117,6 +120,42 @@ const i18nProvider = polyglotI18nProvider(() => ({
                 lastMaintenance: 'Последнее ТО',
             },
         },
+        exchanges: {
+            name: 'Обмен |||| Обмены',
+            fields: {
+                id: 'ID',
+                user_id: 'Пользователь',
+                station_id: 'Станция',
+                old_battery_id: 'Старая батарея',
+                new_battery_id: 'Новая батарея',
+                created_at: 'Дата обмена',
+            },
+        },
+        tariffs: {
+            name: 'Тариф |||| Тарифы',
+            fields: {
+                id: 'ID',
+                name: 'Название',
+                description: 'Описание',
+                price: 'Цена',
+                duration_days: 'Длительность (дни)',
+                max_exchanges_per_day: 'Макс. обменов в день',
+                is_active: 'Активный',
+                created_at: 'Создан',
+                updated_at: 'Обновлен',
+            },
+        },
+        trips: {
+            name: 'Поездка |||| Поездки',
+            fields: {
+                id: 'ID',
+                user_id: 'Пользователь',
+                distance_km: 'Расстояние (км)',
+                duration_min: 'Время (мин)',
+                start_time: 'Начало',
+                end_time: 'Конец',
+            },
+        },
     },
 }), 'ru');
 
@@ -186,6 +225,23 @@ const App = () => {
                     list={BatteryList}
                     edit={BatteryEdit}
                     show={BatteryShow}
+                />
+                <Resource
+                    name="exchanges"
+                    list={ExchangeList}
+                    show={ExchangeShow}
+                />
+                <Resource
+                    name="tariffs"
+                    list={TariffList}
+                    edit={TariffEdit}
+                    show={TariffShow}
+                    create={TariffCreate}
+                />
+                <Resource
+                    name="trips"
+                    list={TripList}
+                    show={TripShow}
                 />
 
                 {/* Дополнительные маршруты */}

--- a/ecobike-admin/src/resources/trips.js
+++ b/ecobike-admin/src/resources/trips.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import {
+    List,
+    Datagrid,
+    TextField,
+    DateField,
+    NumberField,
+    ReferenceField,
+    Show,
+    SimpleShowLayout,
+    Filter,
+    ReferenceInput,
+    SelectInput,
+    DateInput
+} from 'react-admin';
+
+const TripFilter = (props) => (
+    <Filter {...props}>
+        <ReferenceInput source="user_id" reference="users" label="Пользователь">
+            <SelectInput optionText="email" />
+        </ReferenceInput>
+        <DateInput source="start_gte" label="С даты" />
+        <DateInput source="end_lte" label="По дату" />
+    </Filter>
+);
+
+export const TripList = (props) => (
+    <List {...props} filters={<TripFilter />} sort={{ field: 'start_time', order: 'DESC' }}>
+        <Datagrid rowClick="show">
+            <TextField source="id" label="ID" />
+            <ReferenceField source="user_id" reference="users" label="Пользователь">
+                <TextField source="email" />
+            </ReferenceField>
+            <NumberField source="distance_km" label="Расстояние (км)" />
+            <NumberField source="duration_min" label="Время (мин)" />
+            <DateField source="start_time" label="Начало" showTime />
+            <DateField source="end_time" label="Конец" showTime />
+        </Datagrid>
+    </List>
+);
+
+export const TripShow = (props) => (
+    <Show {...props}>
+        <SimpleShowLayout>
+            <TextField source="id" label="ID" />
+            <ReferenceField source="user_id" reference="users" label="Пользователь">
+                <TextField source="email" />
+            </ReferenceField>
+            <NumberField source="distance_km" label="Расстояние (км)" />
+            <NumberField source="duration_min" label="Время (мин)" />
+            <DateField source="start_time" label="Начало" showTime />
+            <DateField source="end_time" label="Конец" showTime />
+        </SimpleShowLayout>
+    </Show>
+);
+
+export default {
+    list: TripList,
+    show: TripShow
+};


### PR DESCRIPTION
## Summary
- add resources for trips, tariffs and exchanges in admin panel
- register new resources and translations

## Testing
- `npm test -- --watchAll=false`
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_b_68a9bae621ac832cad216b1a2e6fb9d2