### PR TITLE
refactor: centralize JSON loading with helper

### DIFF
--- a/app/utils/i18n.js
+++ b/app/utils/i18n.js
@@ -1,4 +1,5 @@
 import Storage from './storage.js';
+import loadJson from './loadJson.js';
 
 const storage = new Storage('eco');
 const SUPPORTED = ['kz', 'ru', 'en'];
@@ -16,8 +17,7 @@ function interpolate(str, params) {
 }
 
 async function load(lang) {
-  const res = await fetch(`./i18n/${lang}.json`);
-  dict = await res.json();
+  dict = await loadJson(`./i18n/${lang}.json`);
   currentLang = lang;
   storage.set('lang', lang);
   document.documentElement.lang = lang;

--- a/app/utils/loadJson.js
+++ b/app/utils/loadJson.js
@@ -1,0 +1,7 @@
+export default async function loadJson(path) {
+  const res = await fetch(path);
+  if (!res.ok) {
+    throw new Error(`Failed to load ${path}: ${res.status}`);
+  }
+  return res.json();
+}

--- a/app/utils/net.js
+++ b/app/utils/net.js
@@ -1,5 +1,6 @@
 import Storage from './storage.js';
 import { queueReport } from './offline.js';
+import loadJson from './loadJson.js';
 
 export async function fetchWithTimeout(url, options = {}, timeout = 8000, retries = 0) {
   for (let attempt = 0; attempt <= retries; attempt++) {
@@ -28,8 +29,7 @@ export function onNetworkChange(handler) {
 
 export async function fetchCities() {
   await new Promise(r => setTimeout(r, 300));
-  const res = await fetch('./data/cities.json');
-  return res.json();
+  return loadJson('./data/cities.json');
 }
 
 export async function fetchAgreementsMeta() {
@@ -64,8 +64,7 @@ async function fetchWithCache(key, url) {
   await new Promise(r => setTimeout(r, delay));
   try {
     if (!isOnline()) throw new Error('offline');
-    const res = await fetch(url);
-    const data = await res.json();
+    const data = await loadJson(url);
     storage.set(key, data);
     return { data, fromCache: false };
   } catch (e) {
@@ -112,8 +111,7 @@ export async function fetchStationMock(stationId) {
   const delay = 300 + Math.random() * 500;
   await new Promise(r => setTimeout(r, delay));
   try {
-    const res = await fetch('./data/stations.json');
-    const list = await res.json();
+    const list = await loadJson('./data/stations.json');
     const station = list.find(s => s.id === stationId);
     if (!station) return { ok: false };
     const free = Math.max(0, station.slots - station.charged);


### PR DESCRIPTION
## Summary
- add `loadJson` utility for fetching JSON files
- refactor i18n and network helpers to use `loadJson`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a9bf38f180832ca64bf08cf2ac9ac9