### PR TITLE
feat: enhance page management in admin panel

### DIFF
--- a/ecobike-admin/src/App.js
+++ b/ecobike-admin/src/App.js
@@ -20,6 +20,13 @@ import { ExchangeList, ExchangeShow } from './resources/exchanges';
 import { TariffList, TariffEdit, TariffShow, TariffCreate } from './resources/tariffs';
 import { TripList, TripShow } from './resources/trips';
 import { CityList, CityEdit, CityShow, CityCreate } from './resources/cities';
+import {
+    ContentPageList,
+    ContentPageEdit,
+    ContentPageCreate,
+    ContentPageShow,
+    ContentPageIcon,
+} from './resources/contentPages';
 
 
 // Дополнительные страницы
@@ -172,6 +179,20 @@ const i18nProvider = polyglotI18nProvider(() => ({
                 updated_at: 'Обновлен',
             },
         },
+        pages: {
+            name: 'Контентная страница |||| Контентные страницы',
+            fields: {
+                id: 'ID',
+                title: 'Заголовок',
+                slug: 'Слаг',
+                meta_title: 'Мета заголовок',
+                meta_description: 'Мета описание',
+                content: 'Содержимое',
+                published: 'Опубликовано',
+                created_at: 'Создано',
+                updated_at: 'Обновлено',
+            },
+        },
     },
 }), 'ru');
 
@@ -265,6 +286,14 @@ const App = () => {
                     edit={CityEdit}
                     show={CityShow}
                     create={CityCreate}
+                />
+                <Resource
+                    name="pages"
+                    list={ContentPageList}
+                    edit={ContentPageEdit}
+                    show={ContentPageShow}
+                    create={ContentPageCreate}
+                    icon={ContentPageIcon}
                 />
 
 

--- a/ecobike-admin/src/resources/contentPages.js
+++ b/ecobike-admin/src/resources/contentPages.js
@@ -1,0 +1,115 @@
+import React from 'react';
+import {
+    List,
+    Datagrid,
+    TextField,
+    Edit,
+    SimpleForm,
+    TextInput,
+    Create,
+    DateField,
+    EditButton,
+    Show,
+    SimpleShowLayout,
+    RichTextField,
+    BooleanField,
+    BooleanInput,
+} from 'react-admin';
+import DescriptionIcon from '@mui/icons-material/Description';
+
+const slugify = (value = '') =>
+    value
+        .toString()
+        .toLowerCase()
+        .trim()
+        .replace(/\s+/g, '-')
+        .replace(/[^a-z0-9а-яё-]/g, '')
+        .replace(/--+/g, '-')
+        .replace(/^-+/, '')
+        .replace(/-+$/, '');
+
+const pageFilters = [
+    <TextInput label="Поиск" source="q" alwaysOn />,
+    <BooleanInput label="Опубликовано" source="published" />,
+];
+export const ContentPageList = (props) => (
+    <List {...props} title="Страницы" filters={pageFilters}>
+        <Datagrid rowClick="show">
+            <TextField source="id" />
+            <TextField source="title" label="Заголовок" />
+            <TextField source="slug" label="Слаг" />
+            <BooleanField source="published" label="Опубликовано" />
+            <DateField source="updated_at" label="Обновлено" />
+            <EditButton />
+        </Datagrid>
+    </List>
+);
+
+export const ContentPageEdit = (props) => (
+    <Edit
+        {...props}
+        title="Редактировать страницу"
+        transform={(data) => ({
+            ...data,
+            slug: slugify(data.slug),
+        })}
+    >
+        <SimpleForm>
+            <TextInput disabled source="id" />
+            <TextInput source="title" label="Заголовок" fullWidth />
+            <TextInput source="slug" label="Слаг" fullWidth />
+            <TextInput source="meta_title" label="Мета заголовок" fullWidth />
+            <TextInput
+                source="meta_description"
+                label="Мета описание"
+                multiline
+                fullWidth
+            />
+            <TextInput source="content" label="Содержимое" multiline fullWidth />
+            <BooleanInput source="published" label="Опубликовано" />
+        </SimpleForm>
+    </Edit>
+);
+
+export const ContentPageCreate = (props) => (
+    <Create
+        {...props}
+        title="Создать страницу"
+        transform={(data) => ({
+            ...data,
+            slug: slugify(data.slug || data.title),
+        })}
+    >
+        <SimpleForm>
+            <TextInput source="title" label="Заголовок" fullWidth />
+            <TextInput source="slug" label="Слаг" fullWidth />
+            <TextInput source="meta_title" label="Мета заголовок" fullWidth />
+            <TextInput
+                source="meta_description"
+                label="Мета описание"
+                multiline
+                fullWidth
+            />
+            <TextInput source="content" label="Содержимое" multiline fullWidth />
+            <BooleanInput source="published" label="Опубликовано" />
+        </SimpleForm>
+    </Create>
+);
+
+export const ContentPageShow = (props) => (
+    <Show {...props} title="Просмотр страницы">
+        <SimpleShowLayout>
+            <TextField source="id" />
+            <TextField source="title" label="Заголовок" />
+            <TextField source="slug" label="Слаг" />
+            <TextField source="meta_title" label="Мета заголовок" />
+            <TextField source="meta_description" label="Мета описание" />
+            <RichTextField source="content" label="Содержимое" />
+            <BooleanField source="published" label="Опубликовано" />
+            <DateField source="created_at" label="Создано" />
+            <DateField source="updated_at" label="Обновлено" />
+        </SimpleShowLayout>
+    </Show>
+);
+
+export const ContentPageIcon = DescriptionIcon;


### PR DESCRIPTION
## Summary
- rename pages resource to contentPages with meta fields and published filter
- update admin configuration and translations for content page CMS

## Testing
- `npm test`
- `(cd ecobike-admin && npm test -- --watchAll=false --passWithNoTests)`

------
https://chatgpt.com/codex/tasks/task_b_68aaefe76f3c832ca994c1a7f8562857